### PR TITLE
Remove cite from list of block elements

### DIFF
--- a/lib/html_press/html.rb
+++ b/lib/html_press/html.rb
@@ -123,7 +123,7 @@ module HtmlPress
     # remove whitespaces outside of block elements
     def process_block_elements (out)
       re = '\\s+(<\\/?(?:area|base(?:font)?|blockquote|body' +
-        '|caption|center|cite|col(?:group)?|dd|dir|div|dl|dt|fieldset|form' +
+        '|caption|center|col(?:group)?|dd|dir|div|dl|dt|fieldset|form' +
         '|frame(?:set)?|h[1-6]|head|hr|html|legend|li|link|map|menu|meta' +
         '|ol|opt(?:group|ion)|p|param|t(?:able|body|head|d|h|r|foot|itle)' +
         '|ul)\\b[^>]*>)'


### PR DESCRIPTION
Fixes bug which causes white space surrounding cite elements to be removed.
